### PR TITLE
Double pore

### DIFF
--- a/porebuilder/__init__.py
+++ b/porebuilder/__init__.py
@@ -1,2 +1,3 @@
-from porebuilder.porebuilder import GraphenePoreSolvent
 from porebuilder.porebuilder import GraphenePore
+from porebuilder.porebuilder import DoubleGraphenePore
+from porebuilder.porebuilder import GraphenePoreSolvent

--- a/porebuilder/porebuilder.py
+++ b/porebuilder/porebuilder.py
@@ -162,15 +162,15 @@ class DoubleGraphenePore(mb.Compound):
         mid_sheet = mb.clone(graphene)
         mid_sheet.spin(1.5708, [1, 0, 0])
         mid_sheet.name = 'MID'
-        mid_sheet.translate([0, pore_width[0] + (graphene.periodicity[2] - 0.335), 0])
+        mid_sheet.translate([0, pore_widths[0] + (graphene.periodicity[2] - 0.335), 0])
         top_sheet = mb.clone(graphene)
         top_sheet.spin(1.5708, [1, 0, 0])
-        top_sheet.translate([0, pore_width[0] + pore_width[1] + 2 * (graphene.periodicity[2] - 0.335), 0])
+        top_sheet.translate([0, pore_widths[0] + pore_widths[1] + 2 * (graphene.periodicity[2] - 0.335), 0])
         top_sheet.name = 'TOP'
         self.add(top_sheet)
         self.add(mid_sheet)
         self.add(bot_sheet)
         self.periodicity[0] = graphene.periodicity[0]
-        self.periodicity[1] = 3 * graphene.periodicity[2] - lattice_spacing[2] + pore_width[0] + pore_width[1]
+        self.periodicity[1] = 3 * graphene.periodicity[2] - lattice_spacing[2] + pore_widths[0] + pore_widths[1]
         self.periodicity[2] = graphene.periodicity[1]
         self.xyz -= np.min(self.xyz, axis=0)

--- a/porebuilder/porebuilder.py
+++ b/porebuilder/porebuilder.py
@@ -171,6 +171,6 @@ class DoubleGraphenePore(mb.Compound):
         self.add(mid_sheet)
         self.add(bot_sheet)
         self.periodicity[0] = graphene.periodicity[0]
-        self.periodicity[1] = 3 * graphene.periodicity[2] - lattice_spacing[2] + pore_widths[0] + pore_widths[1]
+        self.periodicity[1] = 3 * graphene.periodicity[2] - 2 * lattice_spacing[2] + pore_widths[0] + pore_widths[1]
         self.periodicity[2] = graphene.periodicity[1]
         self.xyz -= np.min(self.xyz, axis=0)

--- a/porebuilder/tests/base_test.py
+++ b/porebuilder/tests/base_test.py
@@ -20,7 +20,7 @@ class BaseTest:
     @pytest.fixture
     def DoubleGraphenePore(self):
         from porebuilder.porebuilder import DoubleGraphenePore
-        return DoubleGraphenePore(pore_depth=3, side_dim=3, n_sheets=3, pore_width=[1, 2])
+        return DoubleGraphenePore(pore_depth=3, side_dim=3, n_sheets=3, pore_widths=[1, 2])
 
     @pytest.fixture
     def GraphenePoreSolvent(self):

--- a/porebuilder/tests/base_test.py
+++ b/porebuilder/tests/base_test.py
@@ -18,6 +18,11 @@ class BaseTest:
         return GraphenePore(pore_depth=3, side_dim=3, n_sheets=3, pore_width=1)
 
     @pytest.fixture
+    def DoubleGraphenePore(self):
+        from porebuilder.porebuilder import DoubleGraphenePore
+        return DoubleGraphenePore(pore_depth=3, side_dim=3, n_sheets=3, pore_width=[1, 2])
+
+    @pytest.fixture
     def GraphenePoreSolvent(self):
         from porebuilder.porebuilder import GraphenePoreSolvent
         h2o = mb.load(os.path.join(TESTFILE_DIR, 'tip3p.mol2'))

--- a/porebuilder/tests/base_test.py
+++ b/porebuilder/tests/base_test.py
@@ -20,7 +20,7 @@ class BaseTest:
     @pytest.fixture
     def DoubleGraphenePore(self):
         from porebuilder.porebuilder import DoubleGraphenePore
-        return DoubleGraphenePore(pore_depth=3, side_dim=3, n_sheets=3, pore_widths=[1, 2])
+        return DoubleGraphenePore(pore_depth=3, side_dim=3, n_sheets=3, pore_widths=[1.2, 2.0])
 
     @pytest.fixture
     def GraphenePoreSolvent(self):

--- a/porebuilder/tests/test_porebuilder.py
+++ b/porebuilder/tests/test_porebuilder.py
@@ -53,3 +53,6 @@ class TestPoreBuilder(BaseTest):
             assert particle.xyz[0][0] < box.maxs[0]
             assert particle.xyz[0][1] < box.maxs[1]
             assert particle.xyz[0][2] < box.maxs[2]
+
+    def test_double_periodicity(self, DoubleGraphenePore):
+        assert np.allclose(DoubleGraphenePore.periodicity, [2.9472, 5.545, 2.97774175], rtol=0.01)

--- a/porebuilder/tests/test_porebuilder.py
+++ b/porebuilder/tests/test_porebuilder.py
@@ -14,6 +14,9 @@ class TestPoreBuilder(BaseTest):
     def test_save_solvated(self, GraphenePoreSolvent):
         GraphenePoreSolvent.save(filename='solvated_pore.gro')
 
+    def test_save_double(self, DoubleGraphenePore):
+        DoubleGraphenePore.save(filename='double_pore.gro')
+
     def test_hierarchy_dry(self, GraphenePore):
         assert len(GraphenePore.children) == 2
 


### PR DESCRIPTION
This implements a double pore, which simply adds another clone of the few-layer graphene to construct a second pore. For systems like below, this is slightly improved behavior, as I would not want to have the chunk duplicated twice.

![image](https://user-images.githubusercontent.com/7935382/41811825-959edf90-76dc-11e8-93df-2dcdf29986e6.png)

This could possibly be extended to a system of `n` pores of different sizes, but I don't currently have a use for that type of structure.