### PR TITLE
Add conditional for boxes without bulk regions

### DIFF
--- a/porebuilder/porebuilder.py
+++ b/porebuilder/porebuilder.py
@@ -100,7 +100,8 @@ class GraphenePoreSolvent(mb.Compound):
                             n_sheets=n_sheets, pore_width=pore_width)
 
         box = mb.Box(pore.periodicity)
-        box.maxs[0] += 2 * x_bulk
+        if x_bulk != 0:
+            box.maxs[0] += 2 * x_bulk
 
         system = mb.solvate(pore, solvent, n_solvent, box=box, overlap=0.2)
 


### PR DESCRIPTION
The `GraphenePoreSolvent` class previously wasn't able to initialize a system without a bulk region.  By adding a conditional, the box isn't modified if `x_bulk == 0`.