### PR TITLE
Add support for slit pore dim to solvent

### DIFF
--- a/porebuilder/porebuilder.py
+++ b/porebuilder/porebuilder.py
@@ -117,7 +117,8 @@ class GraphenePoreSolvent(mb.Compound):
         super(GraphenePoreSolvent, self).__init__()
 
         pore = GraphenePore(pore_length=pore_length, pore_depth=pore_depth,
-                            n_sheets=n_sheets, pore_width=pore_width)
+                            n_sheets=n_sheets, pore_width=pore_width,
+                            slit_pore_dim=slit_pore_dim)
 
         box = mb.Box(pore.periodicity)
         if x_bulk != 0:


### PR DESCRIPTION
The `slit_pore_dim` variable was not passed from `GraphenePoreSolvent` to `GraphenePore`. This PR adds that support. 