### PR TITLE
Fix periodicity of empty pore so graphene is in center of box

### DIFF
--- a/porebuilder/porebuilder.py
+++ b/porebuilder/porebuilder.py
@@ -68,19 +68,10 @@ class GraphenePore(mb.Compound):
         top_sheet.name = 'TOP'
         self.add(top_sheet)
         self.add(bot_sheet)
-        if slit_pore_dim == 0:
-            self.periodicity[0] = 2 * graphene.periodicity[2] - lattice_spacing[2] + pore_width
-            self.periodicity[1] = graphene.periodicity[0]
-            self.periodicity[2] = graphene.periodicity[1]
-        elif slit_pore_dim == 1:
-            self.periodicity[0] = graphene.periodicity[0]
-            self.periodicity[1] = 2 * graphene.periodicity[2] - lattice_spacing[2] + pore_width
-            self.periodicity[2] = graphene.periodicity[1]
-        elif slit_pore_dim == 2:
-            self.periodicity[0] = graphene.periodicity[0]
-            self.periodicity[1] = graphene.periodicity[1]
-            self.periodicity[2] = 2 * graphene.periodicity[2] - lattice_spacing[2] + pore_width
         self.xyz -= np.min(self.xyz, axis=0)
+        self.periodicity[0] = np.max(self.xyz[:,0])
+        self.periodicity[1] = np.max(self.xyz[:,1])
+        self.periodicity[2] = np.max(self.xyz[:,2])
 
 
 class GraphenePoreSolvent(mb.Compound):

--- a/porebuilder/tests/test_porebuilder.py
+++ b/porebuilder/tests/test_porebuilder.py
@@ -73,9 +73,9 @@ class TestPoreBuilder(BaseTest):
         box = mb.Box(GraphenePoreSolvent.periodicity)
 
         for particle in GraphenePoreSolvent.particles():
-            assert particle.xyz[0][0] < box.maxs[0]
-            assert particle.xyz[0][1] < box.maxs[1]
-            assert particle.xyz[0][2] < box.maxs[2]
+            assert particle.xyz[0][0] <= box.maxs[0]
+            assert particle.xyz[0][1] <= box.maxs[1]
+            assert particle.xyz[0][2] <= box.maxs[2]
 
     def test_dimension_error(self):
         from porebuilder.porebuilder import GraphenePore, GrapheneSurface
@@ -85,5 +85,12 @@ class TestPoreBuilder(BaseTest):
 
     @pytest.mark.parametrize("dim", (0, 1, 2))
     def test_slitpore_dims(self, dim):
-        from porebuilder.porebuilder import GraphenePore, GrapheneSurface
+        from porebuilder.porebuilder import GraphenePore
         GraphenePore(slit_pore_dim=dim)
+
+    @pytest.mark.parametrize("dim", (0, 1, 2))
+    def test_box_center(self, dim):
+        from porebuilder.porebuilder import GraphenePore
+        pore = GraphenePore(slit_pore_dim=dim)
+        
+        assert np.allclose(pore.center, np.max(pore.xyz, axis=0)/2)


### PR DESCRIPTION
The graphene atoms are not currently centered in the box.  This PR improves on the way in which the periodicity is set for the `mb.Compound` which should center the atoms.  Still need to fix this for `GraphenePoreSolvent`.